### PR TITLE
Fix throw error if no version found

### DIFF
--- a/hooks/pre_install.lua
+++ b/hooks/pre_install.lua
@@ -20,7 +20,7 @@ function PLUGIN:PreInstall(ctx)
     end
 
     if (version == nil) then
-        error("version not found for provided version " .. version)
+        error("version not found for provided version " .. ctx.version)
     end
 
     local arch_type = RUNTIME.archType


### PR DESCRIPTION
if no version found, an error will be throwed:
```
pre_install.lua:23: cannot perform concat operation between string and nil
```

![CleanShot 2024-04-24 at 11 27 35@2x](https://github.com/version-fox/vfox-nodejs/assets/13938334/6a3ac172-ce4a-4997-9592-f5889076b613)
