### PR TITLE
fix(legacy_parser): update version resolution to use ctx.strategy

### DIFF
--- a/hooks/parse_legacy_file.lua
+++ b/hooks/parse_legacy_file.lua
@@ -43,7 +43,7 @@ function PLUGIN:ParseLegacyFile(ctx)
     end
     local query = resolve_version(content)
 
-    query = resolve_legacy_version("latest_installed", query)
+    query = resolve_legacy_version(ctx.strategy, query)
 
     return {
         version = query
@@ -57,6 +57,7 @@ function resolve_version(query)
         query = query:gsub("-", "/")
     end
 
+    -- https://node.org.cn/en/about/previous-releases
     local nodejs_codenames = {
         argon = 4,
         boron = 6,
@@ -66,7 +67,8 @@ function resolve_version(query)
         fermium = 14,
         gallium = 16,
         hydrogen = 18,
-        iron = 20
+        iron = 20,
+        jod = 22
     }
 
     for codename, version_number in pairs(nodejs_codenames) do

--- a/hooks/parse_legacy_file.lua
+++ b/hooks/parse_legacy_file.lua
@@ -57,7 +57,7 @@ function resolve_version(query)
         query = query:gsub("-", "/")
     end
 
-    -- https://node.org.cn/en/about/previous-releases
+    -- https://nodejs.org/zh-cn/about/previous-releases
     local nodejs_codenames = {
         argon = 4,
         boron = 6,

--- a/hooks/parse_legacy_file.lua
+++ b/hooks/parse_legacy_file.lua
@@ -79,7 +79,14 @@ function resolve_version(query)
     end
 
     if query == "lts" or query == "lts/*" then
-        query = tostring(nodejs_codenames[#nodejs_codenames])
+        -- Find the latest LTS version (highest version number)
+        local latest_version = 0
+        for codename, version_number in pairs(nodejs_codenames) do
+            if version_number > latest_version then
+                latest_version = version_number
+            end
+        end
+        query = tostring(latest_version)
     end
 
     return query


### PR DESCRIPTION
Update the legacy version resolution to use the strategy from context instead of hardcoded "latest_installed". Also add the latest Node.js codename (jod) to the mapping table for version resolution.

and the previous max lts version resolution is buggy too:
<img width="1546" height="736" alt="CleanShot 2025-09-28 at 14 36 32@2x" src="https://github.com/user-attachments/assets/f2f59bb4-b223-4cb7-be56-2f1f155e72f3" />
the result of `#nodejs_codenames` is 0, and the nodejs version is nil